### PR TITLE
feat: card date format

### DIFF
--- a/app/routes/entries/index.tsx
+++ b/app/routes/entries/index.tsx
@@ -4,6 +4,7 @@ import { User } from "@supabase/supabase-js";
 import withAuth from "~/utils/withAuth";
 import Navigation from "~/components/navigation";
 import { Entry } from "~/types";
+import dayjs from "dayjs";
 
 export const loader: LoaderFunction = withAuth(
   async ({ supabaseClient, user }) => {
@@ -59,7 +60,7 @@ export default function EntriesList() {
                   ></img>
                 </div>
                 <div className="flex flex-col justify-center gap-1 p-2">
-                    <div className="text-md text-blue-400">{entry.date}</div>
+                    <div className="text-md text-blue-400">{dayjs(entry.date).format('DD MMM, YYYY HH:mm')}</div>
                     <div className="font-bold text-xl">{entry.title}</div>
                     <p className="hidden md:block text-gray-700 text-base">
                       {entry.content}

--- a/app/routes/entries/index.tsx
+++ b/app/routes/entries/index.tsx
@@ -45,12 +45,9 @@ export default function EntriesList() {
       <div className="container grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 lg:grid-cols-3 gap-4 p-2 md:p-0">
         <div className="md:col-start-1 md:col-span-2 lg:col-start-1 lg:col-span-2 order-2 lg:order-none mb-4">
           {entries.map((entry) => (
-            <Link
-              to={`/entries/${entry.id}`}
-              key={entry.id}
-            >
-            <div className="flex space-x-2 rounded-md shadow-sm mt-2 h-28 bg-white hover:bg-slate-50">
-              <div className="w-44 h-28">
+            <Link to={`/entries/${entry.id}`} key={entry.id}>
+              <div className="flex space-x-2 rounded-md shadow-sm mt-2 h-28 bg-white hover:bg-slate-50">
+                <div className="w-44 h-28">
                   <img
                     className="w-full h-full rounded-l-md"
                     src={
@@ -60,13 +57,15 @@ export default function EntriesList() {
                   ></img>
                 </div>
                 <div className="flex flex-col justify-center gap-1 p-2">
-                    <div className="text-md text-blue-400">{dayjs(entry.date).format('DD MMM, YYYY HH:mm')}</div>
-                    <div className="font-bold text-xl">{entry.title}</div>
-                    <p className="hidden md:block text-gray-700 text-base">
-                      {entry.content}
-                    </p>
+                  <div className="text-md text-blue-400">
+                    {dayjs(entry.date).format("DD MMM, YYYY HH:mm")}
+                  </div>
+                  <div className="font-bold text-xl">{entry.title}</div>
+                  <p className="hidden md:block text-gray-700 text-base">
+                    {entry.content}
+                  </p>
                 </div>
-            </div>
+              </div>
             </Link>
           ))}
         </div>
@@ -92,21 +91,21 @@ export default function EntriesList() {
               </svg>
               Add New Entry
             </Link>
-              <div className="hidden md:flex md:flex-col space-y-2 mt-3 p-4 w-full bg-white shadow-sm">
-                <div className="text-xl">
-                  Enjoying <span className="text-pink-400">Happy</span>{" "}
-                  <span className="text-blue-400">Days</span>?
-                </div>
-                <div className="text-gray-500 text-sm">
-                  Our paid plans give you access to a dedicated Account Manager,
-                  unlocks premium features and much more.
-                </div>
-                <Link
-                  to="/"
-                  className="px-4 py-2 border border-pink-400 hover:bg-pink-400 text-pink-400 hover:text-white rounded text-center"
-                >
-                  Upgrade
-                </Link>
+            <div className="hidden md:flex md:flex-col space-y-2 mt-3 p-4 w-full bg-white shadow-sm">
+              <div className="text-xl">
+                Enjoying <span className="text-pink-400">Happy</span>{" "}
+                <span className="text-blue-400">Days</span>?
+              </div>
+              <div className="text-gray-500 text-sm">
+                Our paid plans give you access to a dedicated Account Manager,
+                unlocks premium features and much more.
+              </div>
+              <Link
+                to="/"
+                className="px-4 py-2 border border-pink-400 hover:bg-pink-400 text-pink-400 hover:text-white rounded text-center"
+              >
+                Upgrade
+              </Link>
             </div>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@stripe/stripe-js": "^1.35.0",
         "@supabase/supabase-js": "^1.35.4",
         "cross-env": "^7.0.3",
+        "dayjs": "^1.11.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "stripe": "^10.5.0"
@@ -4661,6 +4662,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "node_modules/deasync": {
       "version": "0.1.26",
@@ -17360,6 +17366,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
       "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
       "dev": true
+    },
+    "dayjs": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+      "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "deasync": {
       "version": "0.1.26",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@stripe/stripe-js": "^1.35.0",
     "@supabase/supabase-js": "^1.35.4",
     "cross-env": "^7.0.3",
+    "dayjs": "^1.11.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "stripe": "^10.5.0"


### PR DESCRIPTION
At the moment the current date format on the entries looks like this:

<img width="1432" alt="Screenshot 2022-09-05 at 13 13 30" src="https://user-images.githubusercontent.com/22655069/188448643-96edc83a-3e2f-435f-a6a7-271addb49ed8.png">

The `dayjs` package has been added and the format on the card has changed:

<img width="1432" alt="Screenshot 2022-09-05 at 13 18 34" src="https://user-images.githubusercontent.com/22655069/188448840-f9f5401d-b89c-461a-82b7-486f5b349a38.png">
